### PR TITLE
Add coverageColumn() for code-coverage-api

### DIFF
--- a/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
+++ b/job-dsl-core/src/main/groovy/javaposse/jobdsl/dsl/views/ColumnsContext.groovy
@@ -283,6 +283,16 @@ class ColumnsContext extends AbstractExtensibleContext {
         columnNodes << new Node(null, 'jenkins.plugins.extracolumns.SCMTypeColumn')
     }
 
+    /**
+     * Adds a column showing code coverage that is used in the project.
+     *
+     * @since 1.78
+     */
+    @RequiresPlugin(id = 'code-coverage-api')
+    void coverageColumn() {
+        columnNodes << new Node(null, 'io.jenkins.plugins.coverage.CoverageColumn')
+    }
+
     @Override
     protected void addExtensionNode(Node node) {
         columnNodes << node


### PR DESCRIPTION
So this;
```
listView('releases') {
	...
	columns {
		...
	}
	configure { view ->
		view / columns << 'io.jenkins.plugins.coverage.CoverageColumn' {
		}
	}
}
```

Can change to this;
```
listView('releases') {
	...
	columns {
		...
		coverageColumn()

	}
}
```